### PR TITLE
Declared main file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "jquery-steps",
   "title": "jQuery Steps",
   "version": "1.1.0",
+  "main": "build/jquery.steps.js",
   "description": "A powerful jQuery wizard plugin that supports accessibility and HTML5",
   "homepage": "http://www.jquery-steps.com",
   "author": {


### PR DESCRIPTION
Added the `main` property to package.json pointing to the main distributable file. This is to provide compatibility with [browserify](https://www.npmjs.com/package/laravel-elixir-browserify) and `require()` functions.